### PR TITLE
Allow for passing of custom config object

### DIFF
--- a/lib/dualshock.js
+++ b/lib/dualshock.js
@@ -24,11 +24,13 @@ var dualShock = function (options) {
     //defaults analogStickSmoothing is turned off
     options.analogStickSmoothing = options.analogStickSmoothing === undefined ? false : options.analogStickSmoothing;
 
+    var controllerConfiguration;
+
     //use passed config or load from built-in configs
     if (typeof options.config === "object") {
-      var controllerConfiguration = options.config;
+      controllerConfiguration = options.config;
     } else {
-      var controllerConfiguration = require('./../controllerConfigurations/' + options.config);
+      controllerConfiguration = require('./../controllerConfigurations/' + options.config);
     }
 
     //loads the configuration;


### PR DESCRIPTION
For our project [Cylon](http://cylonjs.com), we'd like to be able to provide quick/easy support for third-party PS3 controllers. We think the best way to do this is to allow users to pass in their own config objects, e.g.

``` javascript
var DualShock = require("dualshock-controller"),
    config = require("./controller-config.json");
    controller = DualShock({config: config});

// do cool controller event stuff

controller.connect();
```
