### PR TITLE
Remove unnecessary "return this" from constructors

### DIFF
--- a/lib/analogs.js
+++ b/lib/analogs.js
@@ -40,8 +40,6 @@ var Analogs = function (eventEmmiter, analogConfiguration, smoothInput) {
             processStick(analogConfiguration[i], data);
         }
     };
-
-    return this;
 };
 
 module.exports = Analogs;

--- a/lib/buttons.js
+++ b/lib/buttons.js
@@ -44,8 +44,6 @@ var Buttons = function (eventEmmiter, buttonConfiguration) {
             processButton(buttonConfiguration[i], data);
         }
     };
-
-    return this;
 };
 
 module.exports = Buttons;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -72,8 +72,6 @@ var Controller = function (controllerConfig, options) {
         this.emit('disconnecting');
         console.log('node dualshock disconnecting'.yellow);
     };
-
-    return this;
 };
 
 //need to inherit from event emiter.

--- a/lib/gyro.js
+++ b/lib/gyro.js
@@ -50,8 +50,6 @@ var motionProcessor = function (eventEmmiter, motionInputConfiguration, smoothIn
             processAxis(motionInputConfiguration[i], data);
         }
     };
-
-    return this;
 };
 
 module.exports = motionProcessor;

--- a/lib/smoothing.js
+++ b/lib/smoothing.js
@@ -45,8 +45,6 @@ var outputSmoothing = function (smoothInput) {
         return smoothedVal;
 
     };
-
-    return this;
 };
 
 module.exports = outputSmoothing;

--- a/lib/status.js
+++ b/lib/status.js
@@ -24,8 +24,6 @@ var Status = function (eventEmmiter, statusConfiguration) {
             processControllerStatus(statusConfiguration[i], data);
         }
     };
-
-    return this;
 };
 
 module.exports = Status;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -9,8 +9,6 @@ var ds3Utilities = function () {
     this.isWithinVariance = function (x, y, varianceThreshhold) {
         return Math.abs(x - y) > varianceThreshhold;
     };
-
-    return this;
 };
 
 module.exports = ds3Utilities;


### PR DESCRIPTION
Constructor functions implicitly return "this" when called with "new", so there is no need to explicitly return "this" from a constructor.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
