### PR TITLE
Moves grunt and friends into devDependencies block

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,18 +8,16 @@
     "test": "test"
   },
   "dependencies": {
-    "grunt": ">=0.4.1",
-    "grunt-cli": ">=0.1.9",
-    "grunt-contrib-jshint": ">=0.6.4",
-    "grunt-contrib-watch": ">=0.5.3",
-    "node-hid": ">=0.3.0",
-    "colors": ">=0.6.2",
-    "mocha": "~1.17.1",
-    "grunt-mocha-test": "~0.9.0",
-    "sinon": "~1.8.1"
+    "node-hid": "^0.3",
+    "colors": "^0.6"
   },
   "devDependencies": {
-    "mocha": "^1.0",
+    "grunt": "^0.4",
+    "grunt-cli": "^0.1",
+    "grunt-contrib-jshint": "^0.10",
+    "grunt-contrib-watch": "^0.6",
+    "grunt-mocha-test": "^0.10",
+    "mocha": "^1.17",
     "sinon": "^1.8",
     "istanbul": "^0.2"
   },


### PR DESCRIPTION
Further to @rdepena's [comment](https://github.com/rdepena/node-dualshock-controller/pull/18#issuecomment-40746300) on #18, this pull request moves development related dependencies to the devDependencies block.

It also uses the `^` version specifier instead of `>=` or `~` as that's what npm seems to favour at the moment.
