### PR TITLE
added mockery to fix broken travis build, also mocking node-hid will be helpful.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "sinon": "^1.8",
     "istanbul": "^0.2",
     "grunt-jsbeautifier": "^0.2.7",
-    "jshint": "^2.5.0"
+    "jshint": "^2.5.0",
+    "mockery": "^1.4.0"
   },
   "scripts": {
     "test": "grunt test",

--- a/test/dualshock.tests.js
+++ b/test/dualshock.tests.js
@@ -1,7 +1,7 @@
-var DualShock = require('./../lib/dualshock.js'),
-    assert = require('assert'),
+var assert = require('assert'),
     Emitter = require('events').EventEmitter,
-    config = require('../lib/config');
+    config = require('../lib/config'),
+    mockery = require('mockery');
 
 function Device() {
     Emitter.call(this);
@@ -55,7 +55,23 @@ var motions = config.motionInputs;
 var status = config.status;
 
 describe('the DualShock component', function() {
-    var controller, device;
+    //enable mockery and mock node-hid:
+    mockery.enable();
+    var nodeHidMock = {
+        HID: function(vendor, productId) {
+            return {
+                on: function() {
+                    //could use this at some point. nothing atm.
+                }
+            };
+        }
+    };
+    //register mock node-hid.
+    mockery.registerMock('node-hid', nodeHidMock);
+
+    //once mockery is up we can require the dualshock module.
+    var DualShock = require('./../lib/dualshock.js'),
+        controller, device;
 
     before(function() {
         device = new Device();
@@ -63,6 +79,12 @@ describe('the DualShock component', function() {
             config: config,
             device: device
         });
+    });
+
+    //disable mockery so it does not interfere with other tests.
+    after(function() {
+        mockery.deregisterMock('node-hid');
+        mockery.disable();
     });
 
     beforeEach(function() {


### PR DESCRIPTION
node-hid cannot be installed in travis so it breaks the build if you use any module that references it in a test, using mockery to mock node-hid in the dualshock.tests.js.
