### PR TITLE
Capture and emit errors from hid device.

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -144,6 +144,7 @@ const Controller = function() {
     }
 
     device.on('data', processFrame.bind(this));
+    device.on('error', handleException.bind(this));
 
     //subscribe to the exit event:
     process.on('exit', this.disconnect.bind(this));


### PR DESCRIPTION
This PR just ties into the node-hid error event and bubbles it up. If a controller is disconnected after being connected and having listeners setup it will throw a native error which isn't super easy to recover from plus since it's uncaught it bubbles up to electron. By tying into this event disconnects can be handled a bit more gracefully. 

<img width="421" alt="Electron Error" src="https://cloud.githubusercontent.com/assets/3723216/22577201/30fdefea-e98e-11e6-8c26-c9b038ef2196.png">
