### PR TITLE
Add a link to `ds-examples`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,3 +3,6 @@ Examples:
 
 ## Don't use this code as a starting point.
 I do things here that are not neccesary, you are better off looking at the readme in root as it has a cleaner implementation, this is here just so you can test it right away.
+
+If you'd like to see more examples for the DualShock 4, feel free to check out
+[ds-examples](https://github.com/itaisteinherz/ds-examples).


### PR DESCRIPTION
Added a link to [`ds-examples`](https://github.com/itaisteinherz/ds-examples) in `examples/README.md`.
If that's preferable, I can move the link from `examples/README.md` to `README.md`.