### PR TITLE
Fix different PID on newer DS4 models

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -104,7 +104,9 @@ const Controller = function() {
     };
 
     const isController = function(device) {
-        return device.vendorId == controllerConfig.vendorId && device.productId == controllerConfig.productId;
+        var vendor = (device.vendorId == controllerConfig.vendorId);
+        var product = (device.productId == controllerConfig.productId || device.productId == 2508);
+        return vendor && product;
     };
 
     // Public methods


### PR DESCRIPTION
Some newer DS4 controllers have different PID. Fixed in this simple patch.

(Model CUH-ZCT2E that is in Fortnite limited edition have different product ID)