### PR TITLE
Support multiple controllers (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 *.log
 coverage
 *.iml

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ must connect the controller to your computer using a micro-USB cable.
 var dualShock = require('dualshock-controller');
 
 //pass options to init the controller.
-var controller = dualShock(
+var controller = new dualShock.Controller(
     {
         //you can use a ds4 by uncommenting this line.
         //config: "dualshock4-generic-driver",
@@ -110,6 +110,20 @@ controller.on('connection:change', data => console.log(data));
 
 controller.on('charging:change', data => console.log(data));
 
+~~~~
+
+## Support for multiple controllers
+
+To interface with multiple connected controllers of the same type, you can use
+the `index` option.
+
+~~~~ javascript
+var dualShock = require('dualshock-controller');
+
+var
+  player1 = new dualShock.Controller({ config: "dualshock4", index: 0 }),
+  player2 = new dualShock.Controller({ config: "dualshock4", index: 1 }),
+  player3 = new dualShock.Controller({ config: "dualshock3", index: 0 });
 ~~~~
 
 ## <a name="linux-support"></a> Linux support:

--- a/src/analogs.js
+++ b/src/analogs.js
@@ -1,16 +1,15 @@
 'use strict';
 // Module dependencies.
 var dsutilities = require('./utilities'),
-    Smoothing = require('./smoothing'),
-    config = require('./config');
+    Smoothing = require('./smoothing');
 
 //Proccess Analog stick events.
 var Analogs = function(controller) {
 
     var varianceThreshhold = 1,
-        smoothInput = config.getOptions().analogStickSmoothing,
+        smoothInput = controller.config.options.analogStickSmoothing,
         outputSmoothing = new Smoothing(smoothInput),
-        analogSticks = config.getControllerConfig().analogSticks;
+        analogSticks = controller.config.controller.analogSticks;
 
     //Private methods
     var processStick = function(analogStick, data) {

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -1,12 +1,11 @@
 'use strict';
 // Module dependencies.
-var config = require('./config'),
-    dsutilities = require('./utilities');
+var dsutilities = require('./utilities');
 
 //Proccess button events.
 var Buttons = function(controller) {
 
-    var buttons = config.getControllerConfig().buttons;
+    var buttons = controller.config.controller.buttons;
 
     // convert strings to numbers, e.g. "0x01" to 0x01
     // must be converted because JSON doesn't allow numbers with leading zeros

--- a/src/config.js
+++ b/src/config.js
@@ -1,56 +1,37 @@
 'use strict';
-// Module dependencies.
-// we will expose these objects via the manager.
-var options,
-    controllerConfig;
 
-//provides access to the current options and configs.
-var config = {
-    setOptions: function(opts) {
-        //no options were passed
-        options = opts || {};
-
-        // Defaults:
-        var defaultValues = {
-            config: "dualShock3",
-            accelerometerSmoothing: true,
-            analogStickSmoothing: false,
-            logging: false,
-            forceNodeHid: false,
-            linuxJoystickId: 0
-        };
-
-        for (var name in defaultValues) {
-            if (defaultValues.hasOwnProperty(name)) {
-                var target = options[name];
-                var orig = defaultValues[name];
-
-                if (!target) {
-                    options[name] = orig;
-                }
-            }
-        }
-
-        var controllerConfiguration;
-        //use passed config or load from built-in configs
-        if (typeof options.config === "object") {
-            controllerConfiguration = options.config;
-        } else {
-            controllerConfiguration = require('./../controllerConfigurations/' + options.config);
-        }
-
-        //set the current controllerConfiguration
-        config.setControllerConfig(controllerConfiguration);
-    },
-    getOptions: function() {
-        return options;
-    },
-    setControllerConfig: function(config) {
-        controllerConfig = config;
-    },
-    getControllerConfig: function() {
-        return controllerConfig;
-    }
+const defaults = {
+    config: "dualShock3",
+    accelerometerSmoothing: true,
+    analogStickSmoothing: false,
+    logging: false,
+    forceNodeHid: false,
+    linuxJoystickId: 0,
 };
 
-module.exports = config;
+const applyDefaults = function(opts) {
+    var applied = Object.assign({}, opts);
+
+    for (var name in defaults) {
+        if (defaults.hasOwnProperty(name) && !(name in applied)) {
+            applied[name] = defaults[name];
+        }
+    }
+
+    return applied;
+};
+
+const resolveControllerConfiguration = function(opts) {
+    if (typeof opts.config === "string") {
+        return require('./../controllerConfigurations/' + opts.config);
+    }
+
+    return opts.config;
+};
+
+const Config = function(opts) {
+    this.options = applyDefaults(opts || {});
+    this.controller = resolveControllerConfiguration(this.options);
+};
+
+module.exports = Config;

--- a/src/controller.js
+++ b/src/controller.js
@@ -1,23 +1,25 @@
 // Module dependencies.
 const util = require('util'),
-    dsutilities = require('./utilities'),
+    Config = require('./config'),
+    Logger = require('./logger'),
     Emitter = require('events').EventEmitter,
     Gyro = require('./gyro'),
     Analogs = require('./analogs'),
     Buttons = require('./buttons'),
     Status = require('./status'),
     HID = require('node-hid'),
-    config = require('./config'),
     TouchPad = require('./touchpad');
 
 //generic controller object, it will need a controller Configuration with a buttons array passed into its connect function.
-const Controller = function() {
+const Controller = function(opts) {
     'use strict';
     Emitter.call(this);
 
-    const controllerConfig = config.getControllerConfig(),
-        options = config.getOptions(),
-        indexes = controllerConfig.output.indexes,
+    this.config = new Config(opts);
+
+    const config = this.config,
+        logger = new Logger(config),
+        indexes = config.controller.output.indexes,
         analogs = new Analogs(this),
         buttons = new Buttons(this),
         gyro = new Gyro(this),
@@ -60,7 +62,7 @@ const Controller = function() {
             initialValue: ''
         }]
     }].forEach(function(setup) {
-        const entities = controllerConfig[setup.type],
+        const entities = config.controller[setup.type],
             properties = setup.properties;
 
         if (entities.length) {
@@ -79,37 +81,37 @@ const Controller = function() {
         if (this && this.emit) {
             this.emit('error', ex);
         } else {
-            dsutilities.warn(ex);
+            logger.warn(ex);
             throw (ex);
         }
     };
 
     //process data from HID connected device.
     const processFrame = function(data) {
-        if (controllerConfig.motionInputs) {
+        if (config.controller.motionInputs) {
             gyro.process(data);
         }
-        if (controllerConfig.analogSticks) {
+        if (config.controller.analogSticks) {
             analogs.process(data);
         }
-        if (controllerConfig.buttons) {
+        if (config.controller.buttons) {
             buttons.process(data);
         }
-        if (controllerConfig.status) {
+        if (config.controller.status) {
             status.process(data);
         }
-        if (controllerConfig.touchPad) {
+        if (config.controller.touchPad) {
             touchPad.process(data);
         }
     };
 
     const isController = function(device) {
-        return device.vendorId == controllerConfig.vendorId && device.productId == controllerConfig.productId;
+        return device.vendorId == config.controller.vendorId && device.productId == config.controller.productId;
     };
 
     // Public methods
     this.connect = function() {
-        dsutilities.warn('connect method is deprecated, controller now connects upon declaration.');
+        logger.warn('connect method is deprecated, controller now connects upon declaration.');
     };
 
     this.disconnect = function() {
@@ -117,13 +119,13 @@ const Controller = function() {
             device.close();
         }
         this.emit('disconnecting');
-        dsutilities.warn('node dualshock disconnecting');
+        logger.warn('node dualshock disconnecting');
     };
 
     // Used to set controller rumble and light
     this.setExtras = function(data) {
 
-        let buff = controllerConfig.output.defaultBuffer.slice();
+        let buff = config.controller.output.defaultBuffer.slice();
 
         Object.keys(data).forEach(k => {
             buff[indexes[k]] = data[k];
@@ -132,20 +134,21 @@ const Controller = function() {
     };
 
     //connect to the controller.
-    if (typeof options.device === 'undefined') {
-        dsutilities.warn('node dualshock connecting');
+    if (typeof config.options.device === 'undefined') {
+        logger.warn('node dualshock connecting');
 
-        const deviceMeta = HID.devices()
-            .filter(isController)[0];
+        const deviceMeta = HID.devices().
+            sort((a, b) => a.path.localeCompare(b.path)).
+            filter(isController)[config.options.index || 0];
         if (deviceMeta) {
             device = new HID.HID(deviceMeta.path);
         } else {
-            handleException(new Error(`device with VID:${controllerConfig.vendorId} PID:${controllerConfig.productId} not found`));
+            handleException(new Error(`device with VID:${config.controller.vendorId} PID:${config.controller.productId} not found`));
         }
 
     } else {
         // Allow user-specified device
-        device = options.device;
+        device = config.options.device;
     }
 
     device.on('data', processFrame.bind(this));

--- a/src/dualshock.js
+++ b/src/dualshock.js
@@ -1,6 +1,7 @@
+'use strict';
+
 // Module dependencies.
-var Controller = require('./controller'),
-    config = require('./config');
+var Controller = require('./controller');
 
 // This is the app entry point.
 //  options you can pass:
@@ -10,13 +11,11 @@ var Controller = require('./controller'),
 //   analogStickSmoothing : true/false, this will activate analog thumb stick smoothing
 //  }
 var dualShock = function(options) {
-    'use strict';
-
-    //set the current options
-    config.setOptions(options);
-
-    //returns the controller.
-    return new Controller();
+    return new Controller(options);
 };
+
+// Since dualShock() simply delegates to `new Controller()`, allow direct use
+// of the latter.
+dualShock.Controller = Controller;
 
 module.exports = dualShock;

--- a/src/gyro.js
+++ b/src/gyro.js
@@ -1,16 +1,15 @@
 'use strict';
 // Module dependencies.
 var dsutilities = require('./utilities'),
-    Smoothing = require('./smoothing'),
-    config = require('./config');
+    Smoothing = require('./smoothing');
 
 //Proccess button events.
 var motionProcessor = function(controller) {
 
     var varianceThreshhold = 1,
-        smoothInput = config.getOptions().accelerometerSmoothing,
+        smoothInput = controller.config.options.accelerometerSmoothing,
         outputSmoothing = new Smoothing(smoothInput),
-        motionInputs = config.getControllerConfig().motionInputs;
+        motionInputs = controller.config.controller.motionInputs;
 
     //generate event name aliases:
     motionInputs.forEach(function(motionAxis) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Logger = function(config) {
+    this.config = config;
+};
+
+Logger.prototype.warn = function(message) {
+    if (this.config.options.logging) {
+        console.log(message);
+    }
+};
+
+module.exports = Logger;

--- a/src/status.js
+++ b/src/status.js
@@ -1,13 +1,11 @@
 'use strict';
 // Module dependencies.
 
-var config = require('./config');
-
 //Proccess button events.
 var Status = function(controller) {
 
     var buffer = {},
-        status = config.getControllerConfig().status;
+        status = controller.config.controller.status;
 
     var processControllerStatus = function(category, data) {
         var state;

--- a/src/touchpad.js
+++ b/src/touchpad.js
@@ -1,5 +1,3 @@
-const config = require('./config');
-
 function genpBufferFromConf(tpAxis) {
     return {
         name: tpAxis.name,
@@ -12,7 +10,7 @@ function genpBufferFromConf(tpAxis) {
 }
 
 module.exports = function TouchPad(controller) {
-    const touchPad = config.getControllerConfig().touchPad;
+    const touchPad = controller.config.controller.touchPad;
     let pBuffer = {};
 
     function processIsActive(buffer, tpAxis) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,8 +1,6 @@
 'use strict';
 // Module dependencies.
 
-var config = require('./config');
-
 var unique = function unique(x) {
     var result = [];
     for (var i = 0; i < x.length; i++) {
@@ -19,11 +17,6 @@ module.exports = {
     //reduces noise from the controller
     isWithinVariance: function(x, y, varianceThreshhold) {
         return Math.abs(x - y) > varianceThreshhold;
-    },
-    warn: function(message) {
-        if (config.getOptions().logging) {
-            console.log(message);
-        }
     },
     generateEventPrefixAliases: function(eventPrefix) {
         return unique([

--- a/test/analog.tests.js
+++ b/test/analog.tests.js
@@ -3,7 +3,7 @@ var Analogs = require('../src/analogs'),
     assert = require('assert'),
     sinon = require('sinon'),
     EventEmitter = require('events').EventEmitter,
-    config = require('../src/config');
+    Config = require('../src/config');
 
 describe('the Analogs component', function() {
     'use strict';
@@ -24,11 +24,9 @@ describe('the Analogs component', function() {
 
     beforeEach(function() {
         emitter = new EventEmitter();
-        config.setOptions({
-            analogStickSmoothing: false
-        });
-        config.setControllerConfig({
-            analogSticks: mockConfig
+        emitter.config = new Config({
+            analogStickSmoothing: false,
+            config: { analogSticks: mockConfig },
         });
         analogs = new Analogs(emitter);
         spy = new sinon.spy();

--- a/test/buttons.tests.js
+++ b/test/buttons.tests.js
@@ -3,7 +3,7 @@ var Buttons = require('../src/buttons'),
     assert = require('assert'),
     sinon = require('sinon'),
     EventEmitter = require('events').EventEmitter,
-    config = require('../src/config');
+    Config = require('../src/config');
 
 describe('the Buttons component', function() {
     'use strict';
@@ -36,8 +36,8 @@ describe('the Buttons component', function() {
 
     beforeEach(function() {
         emitter = new EventEmitter();
-        config.setControllerConfig({
-            buttons: mockConfig
+        emitter.config = new Config({
+            config: { buttons: mockConfig },
         });
         buttons = new Buttons(emitter);
         spy = new sinon.spy();

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -1,91 +1,68 @@
 'use strict';
 
-var assert = require('assert');
+var assert = require('assert'),
+    Config = require('../src/config');
 
 describe('The Config component', function() {
-    var mockConfig = {
-            vendorId: 1556,
-            productId: 616,
-            output: []
-        },
-        mockOptions = {
+    var mockOptions = {
             config: 'dualShock3',
             accelerometerSmoothing: true,
             logging: false
         },
-        instance = [{
-            name: 'setOptions'
-        }, {
-            name: 'getOptions'
-        }, {
-            name: 'setControllerConfig'
-        }, {
-            name: 'getControllerConfig'
-        }],
-        defaultOptionsInstance = [{
+        defaultOptions = [{
             name: 'config'
         }, {
             name: 'accelerometerSmoothing'
         }, {
             name: 'analogStickSmoothing'
-        }],
-        configA,
-        configB;
-
-    beforeEach(function() {
-        configA = require('../src/config');
-        configB = require('../src/config');
-    });
-
+        }];
 
     describe('object instance', function() {
-        it('should have the following shape', function() {
-            instance.forEach(function(method) {
-                assert.equal(typeof configA[method.name], 'function');
+        var config = new Config(mockOptions);
+
+        describe('config property', function () {
+            it('should be present', function () {
+                assert(config.hasOwnProperty('options'), 'missing a "options" property');
+            });
+
+            it('should be an object', function () {
+                assert.equal(typeof config.options, 'object');
+            });
+
+            it('should include all given properties', function () {
+                for (var option in mockOptions) {
+                    assert.equal(config.options[option], mockOptions[option]);
+                }
             });
         });
-    });
 
-    describe('option methods', function() {
-        it('should be able to save options', function() {
-            configA.setOptions(mockOptions);
-            assert.equal(configA.getOptions(), mockOptions);
-        });
+        describe('controller property', function () {
+            it('should be present', function () {
+                assert(config.hasOwnProperty('controller'), 'missing a "controller" property');
+            });
 
-        it('should provide a single object accross instances', function() {
-            configA.setOptions(mockOptions);
-            assert.equal(configA.getOptions(), configB.getOptions());
-        });
-    });
+            it('should be an object', function () {
+                assert.equal(typeof config.controller, 'object');
+            });
 
-    describe('controllerConfig methods', function() {
-        it('should be able to save controllerConfig settings', function() {
-            configA.setControllerConfig(mockConfig);
-            //change the object
-            mockConfig.vendorId = 22;
-            assert.equal(configA.getControllerConfig(), mockConfig);
-        });
-
-        it('should provide a single object accross instances', function() {
-            configA.setControllerConfig(mockConfig);
-            assert.equal(configA.getControllerConfig(), configB.getControllerConfig());
+            it('should reflect a resolved controller config', function () {
+                assert(config.controller.hasOwnProperty('vendorId'));
+                assert(config.controller.hasOwnProperty('productId'));
+            });
         });
     });
 
     describe('default values', function() {
-        beforeEach(function() {
-            configA.setOptions();
-        });
         it('should apply default values', function() {
-            var ops = configA.getOptions();
-            defaultOptionsInstance.forEach(function(property) {
-                assert.notEqual(ops[property.name], void 0);
+            var config = new Config();
+            defaultOptions.forEach(function(property) {
+                assert.notEqual(config.options[property.name], void 0);
             });
         });
         it('should load default config', function() {
-            var controllerConfig = configA.getControllerConfig();
-            assert.notEqual(controllerConfig, null);
-            assert.notEqual(controllerConfig, void 0);
+            var config = new Config();
+            assert.notEqual(config.controller, null);
+            assert.notEqual(config.controller, void 0);
         });
     });
 });

--- a/test/dualshock.tests.js
+++ b/test/dualshock.tests.js
@@ -76,7 +76,7 @@ describe('the DualShock component', function() {
 
     before(function() {
         device = new Device();
-        controller = DualShock({
+        controller = new DualShock.Controller({
             config: config,
             device: device
         });

--- a/test/gyro.tests.js
+++ b/test/gyro.tests.js
@@ -3,7 +3,7 @@ var Gyro = require('../src/gyro'),
     assert = require('assert'),
     sinon = require('sinon'),
     EventEmitter = require('events').EventEmitter,
-    config = require('../src/config');
+    Config = require('../src/config');
 
 describe('the Gyro component', function() {
     'use strict';
@@ -24,13 +24,11 @@ describe('the Gyro component', function() {
 
     beforeEach(function() {
         emitter = new EventEmitter();
+        emitter.config = new Config({
+            accelerometerSmoothing: false,
+            config: { motionInputs: mockConfig }
+        });
         spy = sinon.spy();
-        config.setOptions({
-            accelerometerSmoothing: false
-        });
-        config.setControllerConfig({
-            motionInputs: mockConfig
-        });
         gyro = new Gyro(emitter);
     });
 

--- a/test/status.tests.js
+++ b/test/status.tests.js
@@ -3,7 +3,7 @@ var Status = require('../src/status'),
     assert = require('assert'),
     sinon = require('sinon'),
     EventEmitter = require('events').EventEmitter,
-    config = require('../src/config');
+    Config = require('../src/config');
 
 describe('the status component', function() {
     var mockConfig = [{
@@ -31,10 +31,10 @@ describe('the status component', function() {
 
     beforeEach(function() {
         emitter = new EventEmitter();
-        spy = sinon.spy();
-        config.setControllerConfig({
-            status: mockConfig
+        emitter.config = new Config({
+            config: { status: mockConfig }
         });
+        spy = sinon.spy();
         status = new Status(emitter, mockConfig);
     });
 


### PR DESCRIPTION
Removed use of global config module in favor of `Config` objects that
can be encapsulated by each `Controller` instance, allowing distinct
instantiations of the latter and avoiding race conditions should
instantiation take place within async events.

Introduced optional `index` option that specifies which of the
discovered HID devices (matched vendor and product ID) to use for the
given controller config. Note that discovered controllers are sorted by
device path before assignment to ensure consistency in selection.

Exposed `Controller` as part of the core module to make multiple
instantiation seem more clear. However, the original `dualShock`
entry-point function was left for backwards compatibility.

Example:

    var ds = require('dualshock-controller');

    var
      ds1 = new ds.Controller({ config: "dualshock4", index: 0 }),
      ds2 = new ds.Controller({ config: "dualshock4", index: 1 }),
      ds3 = new ds.Controller({ config: "dualshock3", index: 0 });